### PR TITLE
Bumps version to v10.17.0-SNAPSHOT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kibiutils",
-  "version": "1.16.0",
+  "version": "1.17.0-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kibiutils",
-  "version": "1.16.0",
+  "version": "1.17.0-SNAPSHOT",
   "description": "Small utility lib for the Kibi project",
   "main": "./lib/kibiutils.js",
   "scripts": {


### PR DESCRIPTION
Bumps version to v10.17.0-SNAPSHOT
After releasing [v10.16.0](https://github.com/sirensolutions/kibiutils/releases/tag/10.16.0)