### PR TITLE
[INVE-13951] Add bulk response checker method in Migration class

### DIFF
--- a/lib/migrations/__tests__/migration.js
+++ b/lib/migrations/__tests__/migration.js
@@ -23,6 +23,7 @@ describe('migrations', function () {
   describe('Migration', function () {
 
     var client = {
+      bulk: function bulk() {},
       search: function search() {},
       scroll: function scroll() {},
       clearScroll: function clearScroll() {},

--- a/lib/migrations/__tests__/simple_migration.js
+++ b/lib/migrations/__tests__/simple_migration.js
@@ -30,6 +30,7 @@ describe('migrations', function () {
     }
   };
   var client = {
+    bulk: function bulk() {},
     search: function search() {},
     clearScroll: function clearScroll() {},
     scroll: function scroll() {}

--- a/lib/migrations/migration.js
+++ b/lib/migrations/migration.js
@@ -79,7 +79,7 @@ var Migration = function () {
           logger.error('(' + error.errorCount + ') ' + error.type + ': ' + causedBy.reason);
           totalErrors += error.errorCount;
         });
-        throw new Error(totalErrors + ' errors occurred in bulk request');
+        throw new Error(totalErrors + ' error(s) occurred in bulk request');
       } else if (bulkResponse.error !== undefined) {
         logger.error(bulkResponse.error);
         throw new Error(bulkResponse.error);

--- a/lib/migrations/migration.js
+++ b/lib/migrations/migration.js
@@ -34,10 +34,31 @@ var BULK_REQUEST_TYPES = ['index', 'delete', 'create', 'update'];
  * }} documentOperationResponse
  */
 function getDocumentOperationResponse(bulkResponseItem) {
-  for (var i = 0; i < BULK_REQUEST_TYPES.length; i++) {
-    var documentOpResponse = bulkResponseItem[BULK_REQUEST_TYPES[i]];
-    if (documentOpResponse) {
-      return documentOpResponse;
+  var _iteratorNormalCompletion = true;
+  var _didIteratorError = false;
+  var _iteratorError = undefined;
+
+  try {
+    for (var _iterator = BULK_REQUEST_TYPES[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+      var actionType = _step.value;
+
+      var documentOpResponse = bulkResponseItem[actionType];
+      if (documentOpResponse) {
+        return documentOpResponse;
+      }
+    }
+  } catch (err) {
+    _didIteratorError = true;
+    _iteratorError = err;
+  } finally {
+    try {
+      if (!_iteratorNormalCompletion && _iterator.return) {
+        _iterator.return();
+      }
+    } finally {
+      if (_didIteratorError) {
+        throw _iteratorError;
+      }
     }
   }
 }

--- a/lib/migrations/migration.js
+++ b/lib/migrations/migration.js
@@ -18,6 +18,30 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 require('babel-polyfill');
 
+var BULK_REQUEST_TYPES = ['index', 'delete', 'create', 'update'];
+
+/**
+ *
+ * @param {{
+ *   ['index'|'delete'|'create'|'update']: {
+ *     error?: Object,
+ *     _id?: string
+ *   }
+ * }} bulkResponseItem
+ * @returns {{
+ *   error?: Object,
+ *   _id?: string
+ * }} documentOperationResponse
+ */
+function getDocumentOperationResponse(bulkResponseItem) {
+  for (var i = 0; i < BULK_REQUEST_TYPES.length; i++) {
+    var documentOpResponse = bulkResponseItem[BULK_REQUEST_TYPES[i]];
+    if (documentOpResponse) {
+      return documentOpResponse;
+    }
+  }
+}
+
 function getErrorIdentifier(error) {
   var errorType = '';
   for (var i = 0; i < 3; i++) {
@@ -44,36 +68,37 @@ var Migration = function () {
     /**
      * Parses the {@link bulkResponse} for errors, logs (unique errors) and throws if found.
      * @param {Object} bulkResponse
-     * @param {string} actionType
      * @param {Logger} logger
      */
-    value: function checkBulkResponse(bulkResponse, actionType, logger) {
+    value: function checkBulkResponse(bulkResponse, logger) {
       if (bulkResponse.errors) {
-        var errorsDuringIndexing = bulkResponse.items.filter(function (ele) {
-          return ele[actionType].error;
+        var errorsDuringIndexing = bulkResponse.items.map(function (item) {
+          return getDocumentOperationResponse(item);
+        }).filter(function (docResp) {
+          return docResp.error;
         });
-        errorsDuringIndexing.reduce(function (uniqueErrors, ele) {
-          var errorIdentifier = getErrorIdentifier(ele.index.error);
+        errorsDuringIndexing.reduce(function (uniqueErrors, docResp) {
+          var errorIdentifier = getErrorIdentifier(docResp.error);
           var existingError = uniqueErrors.find(function (ele) {
             return ele.index.error._identifier === errorIdentifier;
           });
           if (!existingError) {
-            ele.index.error._identifier = errorIdentifier;
-            ele.index.error.errorCount = 1;
-            ele.index.docIds = [ele.index._id];
-            uniqueErrors.push(ele);
+            docResp.error._identifier = errorIdentifier;
+            docResp.error.errorCount = 1;
+            docResp.docIds = [docResp._id];
+            uniqueErrors.push(docResp);
           } else {
             existingError.index.error.errorCount++;
-            if (existingError.index.docIds.length < 5) {
-              existingError.index.docIds.push(ele.index._id);
+            if (docResp._id && existingError.index.docIds.length < 5) {
+              existingError.index.docIds.push(docResp._id);
             }
           }
           return uniqueErrors;
         }, []);
 
         var totalErrors = 0;
-        errorsDuringIndexing.forEach(function (ele) {
-          var error = ele[actionType].error;
+        errorsDuringIndexing.forEach(function (docResp) {
+          var error = docResp.error;
           var causedBy = error.caused_by || error;
           // Should we also log (upto first 5) docIds?
           logger.error('(' + error.errorCount + ') ' + error.type + ': ' + causedBy.reason);
@@ -104,6 +129,8 @@ var Migration = function () {
   }]);
 
   function Migration(configuration) {
+    var _this = this;
+
     _classCallCheck(this, Migration);
 
     if (!configuration) throw new Error('Configuration not specified.');
@@ -111,6 +138,38 @@ var Migration = function () {
     this._client = configuration.client;
     this._config = configuration.config;
     this._logger = configuration.logger;
+
+    // Wrapping bulk method to auto-parse (and throw) any errors
+    var originalBulk = this._client.bulk.bind(this._client);
+    this._client.bulk = function () {
+      var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
+        var resp,
+            _args = arguments;
+        return regeneratorRuntime.wrap(function _callee$(_context) {
+          while (1) {
+            switch (_context.prev = _context.next) {
+              case 0:
+                _context.next = 2;
+                return originalBulk.apply(undefined, _args);
+
+              case 2:
+                resp = _context.sent;
+
+                Migration.checkBulkResponse(resp, _this._logger);
+                return _context.abrupt('return', resp);
+
+              case 5:
+              case 'end':
+                return _context.stop();
+            }
+          }
+        }, _callee, _this);
+      }));
+
+      return function () {
+        return _ref.apply(this, arguments);
+      };
+    }();
   }
 
   _createClass(Migration, [{
@@ -139,23 +198,23 @@ var Migration = function () {
   }, {
     key: 'count',
     value: function () {
-      var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
-        return regeneratorRuntime.wrap(function _callee$(_context) {
+      var _ref2 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee2() {
+        return regeneratorRuntime.wrap(function _callee2$(_context2) {
           while (1) {
-            switch (_context.prev = _context.next) {
+            switch (_context2.prev = _context2.next) {
               case 0:
-                return _context.abrupt('return', 0);
+                return _context2.abrupt('return', 0);
 
               case 1:
               case 'end':
-                return _context.stop();
+                return _context2.stop();
             }
           }
-        }, _callee, this);
+        }, _callee2, this);
       }));
 
       function count() {
-        return _ref.apply(this, arguments);
+        return _ref2.apply(this, arguments);
       }
 
       return count;
@@ -184,23 +243,23 @@ var Migration = function () {
   }, {
     key: 'upgrade',
     value: function () {
-      var _ref2 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee2() {
-        return regeneratorRuntime.wrap(function _callee2$(_context2) {
+      var _ref3 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee3() {
+        return regeneratorRuntime.wrap(function _callee3$(_context3) {
           while (1) {
-            switch (_context2.prev = _context2.next) {
+            switch (_context3.prev = _context3.next) {
               case 0:
-                return _context2.abrupt('return', 0);
+                return _context3.abrupt('return', 0);
 
               case 1:
               case 'end':
-                return _context2.stop();
+                return _context3.stop();
             }
           }
-        }, _callee2, this);
+        }, _callee3, this);
       }));
 
       function upgrade() {
-        return _ref2.apply(this, arguments);
+        return _ref3.apply(this, arguments);
       }
 
       return upgrade;
@@ -220,11 +279,11 @@ var Migration = function () {
   }, {
     key: 'scrollSearch',
     value: function () {
-      var _ref3 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee3(index, type, query, options) {
+      var _ref4 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee4(index, type, query, options) {
         var objects, opts, searchOptions, response;
-        return regeneratorRuntime.wrap(function _callee3$(_context3) {
+        return regeneratorRuntime.wrap(function _callee4$(_context4) {
           while (1) {
-            switch (_context3.prev = _context3.next) {
+            switch (_context4.prev = _context4.next) {
               case 0:
                 objects = [];
                 opts = (0, _lodash.defaults)(options || {}, {
@@ -242,31 +301,31 @@ var Migration = function () {
                   searchOptions.body = query;
                 }
 
-                _context3.next = 6;
+                _context4.next = 6;
                 return this._client.search(searchOptions);
 
               case 6:
-                response = _context3.sent;
+                response = _context4.sent;
 
               case 7:
                 if (!true) {
-                  _context3.next = 19;
+                  _context4.next = 19;
                   break;
                 }
 
                 objects.push.apply(objects, _toConsumableArray(response.hits.hits));
 
                 if (!(objects.length === this.getTotalHitCount(response))) {
-                  _context3.next = 14;
+                  _context4.next = 14;
                   break;
                 }
 
                 if (!response._scroll_id) {
-                  _context3.next = 13;
+                  _context4.next = 13;
                   break;
                 }
 
-                _context3.next = 13;
+                _context4.next = 13;
                 return this._client.clearScroll({
                   body: {
                     scroll_id: response._scroll_id
@@ -274,10 +333,10 @@ var Migration = function () {
                 });
 
               case 13:
-                return _context3.abrupt('break', 19);
+                return _context4.abrupt('break', 19);
 
               case 14:
-                _context3.next = 16;
+                _context4.next = 16;
                 return this._client.scroll({
                   body: {
                     scroll: '1m',
@@ -286,23 +345,23 @@ var Migration = function () {
                 });
 
               case 16:
-                response = _context3.sent;
-                _context3.next = 7;
+                response = _context4.sent;
+                _context4.next = 7;
                 break;
 
               case 19:
-                return _context3.abrupt('return', objects);
+                return _context4.abrupt('return', objects);
 
               case 20:
               case 'end':
-                return _context3.stop();
+                return _context4.stop();
             }
           }
-        }, _callee3, this);
+        }, _callee4, this);
       }));
 
       function scrollSearch(_x, _x2, _x3, _x4) {
-        return _ref3.apply(this, arguments);
+        return _ref4.apply(this, arguments);
       }
 
       return scrollSearch;
@@ -320,34 +379,34 @@ var Migration = function () {
   }, {
     key: 'countHits',
     value: function () {
-      var _ref4 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee4(index, type, query) {
+      var _ref5 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee5(index, type, query) {
         var searchOptions, response;
-        return regeneratorRuntime.wrap(function _callee4$(_context4) {
+        return regeneratorRuntime.wrap(function _callee5$(_context5) {
           while (1) {
-            switch (_context4.prev = _context4.next) {
+            switch (_context5.prev = _context5.next) {
               case 0:
                 searchOptions = {
                   index: index,
                   type: type,
                   body: query
                 };
-                _context4.next = 3;
+                _context5.next = 3;
                 return this._client.count(searchOptions);
 
               case 3:
-                response = _context4.sent;
-                return _context4.abrupt('return', response.count);
+                response = _context5.sent;
+                return _context5.abrupt('return', response.count);
 
               case 5:
               case 'end':
-                return _context4.stop();
+                return _context5.stop();
             }
           }
-        }, _callee4, this);
+        }, _callee5, this);
       }));
 
       function countHits(_x5, _x6, _x7) {
-        return _ref4.apply(this, arguments);
+        return _ref5.apply(this, arguments);
       }
 
       return countHits;

--- a/lib/migrations/migration.js
+++ b/lib/migrations/migration.js
@@ -18,16 +18,91 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 require('babel-polyfill');
 
+function getErrorIdentifier(error) {
+  var errorType = '';
+  for (var i = 0; i < 3; i++) {
+    //Limiting the nesting to 3 for performance
+    errorType += error.type;
+    if (error.caused_by) {
+      error = error.caused_by;
+    } else {
+      break;
+    }
+  }
+  return errorType;
+}
+
 /**
  * The base class for migrations.
  */
 
 var Migration = function () {
-  /**
-   * Creates a new Migration.
-   *
-   * @param configuration {object} The migration configuration.
-   */
+  _createClass(Migration, null, [{
+    key: 'checkBulkResponse',
+
+
+    /**
+     * Parses the {@link bulkResponse} for errors, logs (unique errors) and throws if found.
+     * @param {Object} bulkResponse
+     * @param {string} actionType
+     * @param {Logger} logger
+     */
+    value: function checkBulkResponse(bulkResponse, actionType, logger) {
+      if (bulkResponse.errors) {
+        var errorsDuringIndexing = bulkResponse.items.filter(function (ele) {
+          return ele[actionType].error;
+        });
+        errorsDuringIndexing.reduce(function (uniqueErrors, ele) {
+          var errorIdentifier = getErrorIdentifier(ele.index.error);
+          var existingError = uniqueErrors.find(function (ele) {
+            return ele.index.error._identifier === errorIdentifier;
+          });
+          if (!existingError) {
+            ele.index.error._identifier = errorIdentifier;
+            ele.index.error.errorCount = 1;
+            ele.index.docIds = [ele.index._id];
+            uniqueErrors.push(ele);
+          } else {
+            existingError.index.error.errorCount++;
+            if (existingError.index.docIds.length < 5) {
+              existingError.index.docIds.push(ele.index._id);
+            }
+          }
+          return uniqueErrors;
+        }, []);
+
+        var totalErrors = 0;
+        errorsDuringIndexing.forEach(function (ele) {
+          var error = ele[actionType].error;
+          var causedBy = error.caused_by || error;
+          // Should we also log (upto first 5) docIds?
+          logger.error('(' + error.errorCount + ') ' + error.type + ': ' + causedBy.reason);
+          totalErrors += error.errorCount;
+        });
+        throw new Error(totalErrors + ' errors occurred in bulk request');
+      } else if (bulkResponse.error !== undefined) {
+        logger.error(bulkResponse.error);
+        throw new Error(bulkResponse.error);
+      }
+    }
+
+    /**
+     * Creates a new Migration.
+     *
+     * @param configuration {object} The migration configuration.
+     */
+
+  }, {
+    key: 'description',
+
+    /**
+     * Returns the description of the migration.
+     */
+    get: function get() {
+      return 'No description';
+    }
+  }]);
+
   function Migration(configuration) {
     _classCallCheck(this, Migration);
 
@@ -37,11 +112,6 @@ var Migration = function () {
     this._config = configuration.config;
     this._logger = configuration.logger;
   }
-
-  /**
-   * Returns the description of the migration.
-   */
-
 
   _createClass(Migration, [{
     key: 'parseJSON',
@@ -296,11 +366,6 @@ var Migration = function () {
         // eslint-disable-next-line no-console
         warning: console.warn
       };
-    }
-  }], [{
-    key: 'description',
-    get: function get() {
-      return 'No description';
     }
   }]);
 

--- a/lib/migrations/simple_migration.js
+++ b/lib/migrations/simple_migration.js
@@ -12,6 +12,8 @@ var _migration2 = _interopRequireDefault(_migration);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -160,7 +162,7 @@ var SimpleMigration = function (_Migration) {
     key: 'upgrade',
     value: function () {
       var _ref2 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee2() {
-        var migrationCount, _getSearchParams3, index, type, query, objects, bulkBody, upgradeCount, _iteratorNormalCompletion2, _didIteratorError2, _iteratorError2, _iterator2, _step2, savedObject, _ref3, _index, _type, _id, _source;
+        var migrationCount, _getSearchParams3, index, type, query, objects, bulkBody, upgradeCount, bulkAction, _iteratorNormalCompletion2, _didIteratorError2, _iteratorError2, _iterator2, _step2, savedObject, _ref3, _index, _type, _id, _source, bulkResponse;
 
         return regeneratorRuntime.wrap(function _callee2$(_context2) {
           while (1) {
@@ -173,7 +175,7 @@ var SimpleMigration = function (_Migration) {
                 migrationCount = _context2.sent;
 
                 if (!(migrationCount > 0)) {
-                  _context2.next = 52;
+                  _context2.next = 55;
                   break;
                 }
 
@@ -185,32 +187,33 @@ var SimpleMigration = function (_Migration) {
                 objects = _context2.sent;
                 bulkBody = [];
                 upgradeCount = 0;
+                bulkAction = 'index';
                 _iteratorNormalCompletion2 = true;
                 _didIteratorError2 = false;
                 _iteratorError2 = undefined;
-                _context2.prev = 13;
+                _context2.prev = 14;
                 _iterator2 = objects[Symbol.iterator]();
 
-              case 15:
+              case 16:
                 if (_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done) {
-                  _context2.next = 34;
+                  _context2.next = 35;
                   break;
                 }
 
                 savedObject = _step2.value;
-                _context2.next = 19;
+                _context2.next = 20;
                 return this.checkOutdated(savedObject);
 
-              case 19:
+              case 20:
                 if (!_context2.sent) {
-                  _context2.next = 31;
+                  _context2.next = 32;
                   break;
                 }
 
-                _context2.next = 22;
+                _context2.next = 23;
                 return this._upgradeObject(savedObject);
 
-              case 22:
+              case 23:
                 _ref3 = _context2.sent;
                 _index = _ref3._index;
                 _type = _ref3._type;
@@ -218,75 +221,78 @@ var SimpleMigration = function (_Migration) {
                 _source = _ref3._source;
 
                 _source[_source.type].version = this.newVersion;
-                bulkBody.push({
-                  index: { _index: _index, _type: _type, _id: _id }
-                });
+                bulkBody.push(_defineProperty({}, bulkAction, { _index: _index, _type: _type, _id: _id }));
                 bulkBody.push(_source);
                 upgradeCount++;
 
-              case 31:
+              case 32:
                 _iteratorNormalCompletion2 = true;
-                _context2.next = 15;
+                _context2.next = 16;
                 break;
 
-              case 34:
-                _context2.next = 40;
+              case 35:
+                _context2.next = 41;
                 break;
 
-              case 36:
-                _context2.prev = 36;
-                _context2.t0 = _context2['catch'](13);
+              case 37:
+                _context2.prev = 37;
+                _context2.t0 = _context2['catch'](14);
                 _didIteratorError2 = true;
                 _iteratorError2 = _context2.t0;
 
-              case 40:
-                _context2.prev = 40;
+              case 41:
                 _context2.prev = 41;
+                _context2.prev = 42;
 
                 if (!_iteratorNormalCompletion2 && _iterator2.return) {
                   _iterator2.return();
                 }
 
-              case 43:
-                _context2.prev = 43;
+              case 44:
+                _context2.prev = 44;
 
                 if (!_didIteratorError2) {
-                  _context2.next = 46;
+                  _context2.next = 47;
                   break;
                 }
 
                 throw _iteratorError2;
 
-              case 46:
-                return _context2.finish(43);
-
               case 47:
-                return _context2.finish(40);
+                return _context2.finish(44);
 
               case 48:
+                return _context2.finish(41);
+
+              case 49:
                 if (!(upgradeCount > 0)) {
-                  _context2.next = 51;
+                  _context2.next = 54;
                   break;
                 }
 
-                _context2.next = 51;
+                _context2.next = 52;
                 return this._client.bulk({
                   refresh: true,
                   body: bulkBody
                 });
 
-              case 51:
+              case 52:
+                bulkResponse = _context2.sent;
+
+                _migration2.default.checkBulkResponse(bulkResponse, bulkAction, this.logger);
+
+              case 54:
                 return _context2.abrupt('return', upgradeCount);
 
-              case 52:
+              case 55:
                 return _context2.abrupt('return', migrationCount);
 
-              case 53:
+              case 56:
               case 'end':
                 return _context2.stop();
             }
           }
-        }, _callee2, this, [[13, 36, 40, 48], [41,, 43, 47]]);
+        }, _callee2, this, [[14, 37, 41, 49], [42,, 44, 48]]);
       }));
 
       function upgrade() {

--- a/lib/migrations/simple_migration.js
+++ b/lib/migrations/simple_migration.js
@@ -162,7 +162,7 @@ var SimpleMigration = function (_Migration) {
     key: 'upgrade',
     value: function () {
       var _ref2 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee2() {
-        var migrationCount, _getSearchParams3, index, type, query, objects, bulkBody, upgradeCount, bulkAction, _iteratorNormalCompletion2, _didIteratorError2, _iteratorError2, _iterator2, _step2, savedObject, _ref3, _index, _type, _id, _source, bulkResponse;
+        var migrationCount, _getSearchParams3, index, type, query, objects, bulkBody, upgradeCount, bulkAction, _iteratorNormalCompletion2, _didIteratorError2, _iteratorError2, _iterator2, _step2, savedObject, _ref3, _index, _type, _id, _source;
 
         return regeneratorRuntime.wrap(function _callee2$(_context2) {
           while (1) {
@@ -175,7 +175,7 @@ var SimpleMigration = function (_Migration) {
                 migrationCount = _context2.sent;
 
                 if (!(migrationCount > 0)) {
-                  _context2.next = 55;
+                  _context2.next = 53;
                   break;
                 }
 
@@ -266,7 +266,7 @@ var SimpleMigration = function (_Migration) {
 
               case 49:
                 if (!(upgradeCount > 0)) {
-                  _context2.next = 54;
+                  _context2.next = 52;
                   break;
                 }
 
@@ -277,17 +277,12 @@ var SimpleMigration = function (_Migration) {
                 });
 
               case 52:
-                bulkResponse = _context2.sent;
-
-                _migration2.default.checkBulkResponse(bulkResponse, bulkAction, this.logger);
-
-              case 54:
                 return _context2.abrupt('return', upgradeCount);
 
-              case 55:
+              case 53:
                 return _context2.abrupt('return', migrationCount);
 
-              case 56:
+              case 54:
               case 'end':
                 return _context2.stop();
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kibiutils",
-  "version": "10.18.0",
+  "version": "10.18.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kibiutils",
-  "version": "10.18.0",
+  "version": "10.18.1",
   "description": "Small utility lib for the Kibi project",
   "main": "./lib/kibiutils.js",
   "scripts": {

--- a/src/migrations/__tests__/migration.js
+++ b/src/migrations/__tests__/migration.js
@@ -11,13 +11,14 @@ describe('migrations', function () {
   describe('Migration', function () {
 
     const client = {
+      bulk: () => {},
       search: () => {},
       scroll: () => {},
       clearScroll: () => {},
-      count:  () => ({ count: 15 })
+      count: () => ({ count: 15 })
     };
     const configuration = {
-      index:  'index',
+      index: 'index',
       client: client
     };
 
@@ -46,8 +47,8 @@ describe('migrations', function () {
         expect(result).to.be(15);
         expect(client.count.calledWith({
           index: index,
-          type:  type,
-          body:  query
+          type: type,
+          body: query
         }));
       });
 
@@ -69,18 +70,18 @@ describe('migrations', function () {
             if (searchOptions.index === 'empty') {
               return {
                 _scroll_id: `${esApi}_scroll_id`,
-                hits:       {
+                hits: {
                   total: formatTotalHits(0, esApi),
-                  hits:  []
+                  hits: []
                 }
               };
             }
 
             return {
               _scroll_id: `${esApi}_scroll_id`,
-              hits:       {
+              hits: {
                 total: formatTotalHits(100, esApi),
-                hits:  new Array(10)
+                hits: new Array(10)
               }
             };
           });
@@ -88,9 +89,9 @@ describe('migrations', function () {
           scroll = sinon.stub(client, 'scroll').callsFake(function (scrollOptions) {
             return {
               _scroll_id: scrollOptions.body.scroll_id,
-              hits:       {
+              hits: {
                 total: formatTotalHits(100, esApi),
-                hits:  new Array(10)
+                hits: new Array(10)
               }
             };
           });
@@ -140,18 +141,18 @@ describe('migrations', function () {
           sinon.assert.calledOnce(search);
           sinon.assert.alwaysCalledWith(search,
             {
-              index:  index,
-              type:   type,
+              index: index,
+              type: type,
               scroll: '1m',
-              size:   options.size,
-              body:   query
+              size: options.size,
+              body: query
             });
 
           expect(scroll.callCount).to.be(9);
           for (let i = 0; i < scroll.callCount; i++) {
             expect(scroll.getCall(i).args[0]).to.eql({
               body: {
-                scroll:    '1m',
+                scroll: '1m',
                 scroll_id: `${esApi}_scroll_id`
               }
             });

--- a/src/migrations/__tests__/simple_migration.js
+++ b/src/migrations/__tests__/simple_migration.js
@@ -14,6 +14,7 @@ describe('migrations', function () {
     get: () => KIBANA_INDEX
   };
   const client = {
+    bulk: () => {},
     search: () => {},
     clearScroll: () => {},
     scroll: () => {}

--- a/src/migrations/migration.js
+++ b/src/migrations/migration.js
@@ -17,8 +17,8 @@ const BULK_REQUEST_TYPES = ['index', 'delete', 'create', 'update'];
  * }} documentOperationResponse
  */
 function getDocumentOperationResponse(bulkResponseItem) {
-  for (let i = 0; i < BULK_REQUEST_TYPES.length; i++) {
-    const documentOpResponse = bulkResponseItem[BULK_REQUEST_TYPES[i]];
+  for (let actionType of BULK_REQUEST_TYPES) {
+    const documentOpResponse = bulkResponseItem[actionType];
     if (documentOpResponse) {
       return documentOpResponse;
     }

--- a/src/migrations/migration.js
+++ b/src/migrations/migration.js
@@ -59,7 +59,7 @@ export default class Migration {
         logger.error(`(${error.errorCount}) ${error.type}: ${causedBy.reason}`);
         totalErrors += error.errorCount;
       });
-      throw new Error(`${totalErrors} errors occurred in bulk request`);
+      throw new Error(`${totalErrors} error(s) occurred in bulk request`);
 
     } else if (bulkResponse.error !== undefined) {
       logger.error(bulkResponse.error);

--- a/src/migrations/simple_migration.js
+++ b/src/migrations/simple_migration.js
@@ -71,11 +71,10 @@ export default class SimpleMigration extends Migration {
       }
 
       if (upgradeCount > 0) {
-        const bulkResponse = await this._client.bulk({
+        await this._client.bulk({
           refresh: true,
-          body:    bulkBody
+          body: bulkBody
         });
-        Migration.checkBulkResponse(bulkResponse, bulkAction, this.logger);
       }
       return upgradeCount;
     }

--- a/src/migrations/simple_migration.js
+++ b/src/migrations/simple_migration.js
@@ -57,12 +57,13 @@ export default class SimpleMigration extends Migration {
       const objects = await this.scrollSearch(index, type, query, this.scrollOptions);
       const bulkBody = [];
       let upgradeCount = 0;
+      const bulkAction = 'index';
       for (const savedObject of objects) {
         if (await this.checkOutdated(savedObject)) {
           const { _index, _type, _id, _source } = await this._upgradeObject(savedObject);
           _source[_source.type].version = this.newVersion;
           bulkBody.push({
-            index: { _index, _type, _id }
+            [bulkAction]: { _index, _type, _id }
           });
           bulkBody.push(_source);
           upgradeCount++;
@@ -70,10 +71,11 @@ export default class SimpleMigration extends Migration {
       }
 
       if (upgradeCount > 0) {
-        await this._client.bulk({
+        const bulkResponse = await this._client.bulk({
           refresh: true,
           body:    bulkBody
         });
+        Migration.checkBulkResponse(bulkResponse, bulkAction, this.logger);
       }
       return upgradeCount;
     }


### PR DESCRIPTION
Now, if a document fails indexing in bulk request (Previously, no logs or error tracking. Sometimes [infinite loops](https://sirensolutions.atlassian.net/browse/INVE-13733) due to untraced errors):
### This PR:
![image](https://user-images.githubusercontent.com/18154526/106292833-35cfac00-6245-11eb-8ba8-f9a93172fa3b.png)
### Before this PR:
![image](https://user-images.githubusercontent.com/18154526/106489461-b6441600-64ac-11eb-807e-bd2784f69845.png)


# TODO After Merge.

- [ ] Tag a new release.
- [ ] Bump up kibiutils version in [kibi-internal](https://github.com/sirensolutions/kibi-internal/blob/550889967e21b96a07d7b43e9b05379ed70b0a55/package.json#L207) to the new tag (v10.18.0).
